### PR TITLE
logic error caused by reusing loop variables

### DIFF
--- a/lib/compose.js
+++ b/lib/compose.js
@@ -229,9 +229,9 @@ define([], function(){
 					if(result instanceof Constructor){
 						instance = result;
 					}else{
-						for(var i in result){
-							if(result.hasOwnProperty(i)){
-								instance[i] = result[i];
+						for(var key in result){
+							if(result.hasOwnProperty(key)){
+								instance[key] = result[key];
 							}
 						}
 					}


### PR DESCRIPTION
changed `i` to `key` in inner for loop
