### PR TITLE
`-constructed-` signal for extending `dojo.declare` classes

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -237,6 +237,9 @@ define([], function(){
 					}
 				}
 			}
+			if(typeof instance["-constructed-"] == "function"){
+				instance["-constructed-"].apply(instance, arguments);
+			}
 			return instance;
 		}
 		Constructor._getConstructors = function(){

--- a/compose.profile.js
+++ b/compose.profile.js
@@ -1,0 +1,27 @@
+var testResourceRe = /^compose\/test\//;
+var copyOnly = function(mid){
+  return mid in {
+    "compose/compose.profile": 1,
+    "compose/package.json": 1
+  };
+};
+
+var profile = {
+  resourceTags:{
+    test: function(filename, mid){
+      return testResourceRe.test(mid) || mid === "compose/test";
+    },
+
+    copyOnly: function(filename, mid){
+      return copyOnly(mid);
+    },
+
+    amd: function(filename, mid){
+      return !copyOnly(mid) && (/\.js$/).test(filename);
+    }
+  },
+
+  trees:[
+    [".", ".", /(\/\.)|(~$)/]
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -27,5 +27,6 @@
   "mappings":{
     "patr": "http://github.com/kriszyp/patr/zipball/v0.2.5"
   },
-  "icon": "http://icons.iconarchive.com/icons/kawsone/teneo/64/BiiBall-icon.png"
+  "icon": "http://icons.iconarchive.com/icons/kawsone/teneo/64/BiiBall-icon.png",
+  "dojoBuild": "compose.profile.js"
 }


### PR DESCRIPTION
Not expecting this to be merged, but it's the easiest way to start a discussion.

I'm using Compose with a `dojo.declare` class (`dijit/_WidgetBase`) as a base class. This works great, except that the `_WidgetBase` constructor kicks of widget creation before other Compose base classes have a chance to be applied.

With this change, `-constructed-` will be invoked after all base constructors are applied, at which point I can kick off widget creation.

```
Compose(_WidgetBase, {
  postscript: function(){},
  "-constructed-": function(params, srcNodeRef){
    this.create(params, srcNodeRef);
  }
});
```

Thoughts?
