### PR TITLE
instance.constructor does not match the function used to create the instance

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -245,6 +245,7 @@ define([], function(){
 		var constructors = getConstructors(arguments), 
 			constructorsLength = constructors.length;
 		Constructor.extend = extend;
+		prototype.constructor = Constructor;
 		Constructor.prototype = prototype;
 		return Constructor;
 	};

--- a/test/compose.js
+++ b/test/compose.js
@@ -263,6 +263,7 @@ exports.testExtendError = function(){
 	assert.equal(error.toString(), "CustomError: test");
 	assert.equal(error instanceof CustomError, true);
 	assert.equal(error instanceof Error, true);
+	assert.equal(error.constructor, CustomError);
 }
 exports.testDiamond = function(){
 	var baseCallCount = 0, sub1CallCount = 0, sub2CallCount = 0, fooCallCount = 0, fooSub1Count = 0, fooSub2Count = 0;


### PR DESCRIPTION
sometimes, you may want to hang things off the constructor - "static" properties.  to access these generically from an instance, you would use `this.constructor` to get to the constructor.  to make this work, `prototype.constructor` needs to be set to the constructor returned from compose.

``` js
var Foo = compose(function () {
    // using this.constructor allows subclasses 
    // to define their own important things but
    // still apply this logic
    for (var i in this.constructor.important) {
        // do important things
    }
});

Foo.important = {
   nothing: false
};

var Bar = compose(Foo, {
    stuff: '...'
});

Bar.important = {
    stuff: true
};

// it.constructor should be Bar
var it = new Bar();
```

this pull request adds a test that should show the problem and also includes a fix.

btw, you may want to look at updating the package.json as well so that `dependencies` -> `devDependencies` and point to the latest version of patr
