### PR TITLE
Compose.expand

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -221,6 +221,25 @@ define([], function(){
 		Constructor._getBases = function(prototype){
 			return prototype ? prototypes : constructors;
 		};
+		// expands an existing compose instance
+		Constructor.expand = function(external){
+			var externalConstructors = external._getBases(),
+				externalPrototypes = external._getBases(true),
+				i, 
+				ii;
+				
+			for (i = 0, ii = externalConstructors.length; i < ii; i += 1) {
+				constructors.push(externalConstructors[i]);
+			}
+			constructorsLength += externalConstructors.length;
+			
+			// Expand the prototype
+			for(var key in external.prototype) {
+				if (this.prototype[key] === undefined) {
+					this.prototype[key] = external.prototype[key];
+				}
+			}
+		};
 		// now get the prototypes and the constructors
 		var constructors = getBases(args), 
 			constructorsLength = constructors.length;

--- a/compose.js
+++ b/compose.js
@@ -222,23 +222,19 @@ define([], function(){
 			return prototype ? prototypes : constructors;
 		};
 		// expands an existing compose instance
-		Constructor.expand = function(external){
-			var externalConstructors = external._getBases(),
-				externalPrototypes = external._getBases(true),
-				i, 
-				ii;
-				
-			for (i = 0, ii = externalConstructors.length; i < ii; i += 1) {
-				constructors.push(externalConstructors[i]);
-			}
-			constructorsLength += externalConstructors.length;
+		Constructor.expand = function(){
+			var expanded = this.extend.apply(
+				this, 
+				Array.prototype.slice.call(arguments)
+					.concat(this)
+				);
 			
-			// Expand the prototype
-			for(var key in external.prototype) {
-				if (this.prototype[key] === undefined) {
-					this.prototype[key] = external.prototype[key];
-				}
-			}
+			// Update the prototype
+			this.prototype = expanded.prototype;
+			
+			// Update the constructors
+			constructors = expanded._getBases();
+			constructorsLength = constructors.length;
 		};
 		// now get the prototypes and the constructors
 		var constructors = getBases(args), 

--- a/compose.js
+++ b/compose.js
@@ -215,6 +215,7 @@ define([], function(){
 					}
 				}	
 			}
+			expandable = false;
 			return instance;
 		}
 		// create a function that can retrieve the bases (constructors or prototypes)
@@ -223,10 +224,14 @@ define([], function(){
 		};
 		// expands an existing compose instance
 		Constructor.expand = function(){
+			if (! expandable) {
+				throw new Error('Compose can only expand until the first instantiation of an object');
+			}
 			var expanded = this.extend.apply(
 				this, 
-				Array.prototype.slice.call(arguments)
-					.concat(this)
+				[this].concat(
+					Array.prototype.slice.call(arguments)
+					)
 				);
 			
 			// Update the prototype
@@ -243,6 +248,7 @@ define([], function(){
 			args[args.length - 1] = prototype;
 		}
 		var prototypes = getBases(args, true);
+		var expandable = true;
 		Constructor.extend = extend;
 		if(!Compose.secure){
 			prototype.constructor = Constructor;


### PR DESCRIPTION
Hello Kriszyp,

I've been working with compose for a while now, and utterly loving my experience with it. I've recently had an idea on how to expand its functionality.

Its worth nothing that the code I've sent a pull request for likely needs more work doing to it, so see this as more of a work in progress, I'm aware there maybe security implications in regards to my changing the 'constructorsLength' variable, so this maybe a pointless submission.

Firstly I think I need to exemplify its usage, to help it make sense, basically I use compose with RequireJS, so my project organisation consists of lots of small compose files, that are used in a moduler fashion. To make unit testing highly complex objects easier, I've found that breaking functionality down into smaller and smaller blocks helps improve the quality of my code, and as such the ability to expand composed objects is very appealing to me.

To demo this I've prepared the following gist https://gist.github.com/1613428

The general idea is that each area of functionality relating to a specific object can be broken down and tested in separation, then using RequireJS all of the sub modules can be composed into one module, and used as normal.

Feel free to be as critical as you feel the need, as I understand this implementation likely has some flaws.

Thanks
Iain
